### PR TITLE
Fix go.mod name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module pstrobl96/buddy-prometheus-exporter
+module github.com/pstrobl96/buddy-prometheus-exporter
 
 go 1.20
 


### PR DESCRIPTION
Without this, the exporter can't be installed via `go install github.com/pstrobl96/buddy-prometheus-exporter@lastest`